### PR TITLE
feat: add interactive storage ops console to hpe-vm-diag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 
 | Script | Description |
 | --- | --- |
-| `hpe-vm-diag.py` | Runs system diagnostics including OS, virtualization, and storage checks. |
+| `hpe-vm-diag.py` | Runs system diagnostics including OS, virtualization, and storage checks. Includes a root-only "Storage Ops" console (iSCSI + block views + GFS2 tooling). |
 


### PR DESCRIPTION
## Summary
- add a Storage Ops menu with a root check, shared command runner, and interactive submenus for iSCSI, block device views, and GFS2 workflows
- implement the expected iscsiadm operations, multipath visibility, and GFS2 maintenance actions with safe prompts and reminders
- document the new Storage Ops console entry point in the README

## Testing
- python3 -m py_compile scripts/hpe-vm-diag.py

------
https://chatgpt.com/codex/tasks/task_e_6900b5cf75108327bdd3d446979b913f